### PR TITLE
adding producing of sources jar as good standard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,19 @@
           <target>1.7</target>
         </configuration>
       </plugin>
-      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Our nexus validation rule fails on nonexistent sources jar, producing sources jar is a good standard