### PR TITLE
JBPM-6672 - Stunner - Add support for polylines

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorControlImplTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorControlImplTest.java
@@ -70,6 +70,9 @@ public class WiresConnectorControlImplTest {
     private AbstractDirectionalMultiPointShape line;
 
     @Mock
+    private Shape<?> lineShape;
+
+    @Mock
     private ScratchPad scratchPad;
 
     @Mock
@@ -160,6 +163,8 @@ public class WiresConnectorControlImplTest {
         when(line.getPathPartList()).thenReturn(pathPartList);
         when(line.getComputedLocation()).thenReturn(location);
         when(line.getBoundingBox()).thenReturn(boundingBox);
+        when(line.asShape()).thenReturn(lineShape);
+        when(lineShape.getPathPartList()).thenReturn(pathPartList);
         when(connector.getLine()).thenReturn(line);
         when(scratchPad.getContext()).thenReturn(context);
         when(context.getImageData(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(backImage);

--- a/src/test/java/com/ait/lienzo/client/widget/LienzoHandlerManagerTest.java
+++ b/src/test/java/com/ait/lienzo/client/widget/LienzoHandlerManagerTest.java
@@ -46,6 +46,9 @@ public class LienzoHandlerManagerTest {
     private Viewport viewport;
 
     @Mock
+    private Transform transform;
+
+    @Mock
     private LienzoPanel lienzoPanel;
 
     @Mock
@@ -113,6 +116,7 @@ public class LienzoHandlerManagerTest {
         doReturn(dragLayer).when(lienzoPanel).getDragLayer();
         doReturn(DragMouseControl.LEFT_MOUSE_ONLY).when(lienzoPanel).getDragMouseButtons();
         doReturn(viewport).when(lienzoPanel).getViewport();
+        doReturn(transform).when(viewport).getTransform();
 
         manager = spy(new LienzoHandlerManager(lienzoPanel));
     }


### PR DESCRIPTION
Stunner - Add support for polylines

- Connectors now support polylines.
- Polyline segments now snap at straight angles.

JIRA:
https://issues.jboss.org/browse/JBPM-6672

@romartin 
@tiagodolphine 
@LuboTerifaj 