### PR TITLE
[7.7.x] RHPAM-845 (JBPM-7129) - Stunner - Allow optional size constraints for shapes

### DIFF
--- a/src/main/java/com/ait/lienzo/test/stub/Attributes.java
+++ b/src/main/java/com/ait/lienzo/test/stub/Attributes.java
@@ -787,6 +787,54 @@ public class Attributes
         put(Attribute.HEIGHT.getProperty(), height);
     }
 
+    public final void setMinWidth(final Double minWidth)
+    {
+        if (null != minWidth)
+        {
+            put(Attribute.MIN_WIDTH.getProperty(), minWidth);
+        }
+        else
+        {
+            remove(Attribute.MIN_WIDTH.getProperty());
+        }
+    }
+
+    public final void setMaxWidth(final Double maxWidth)
+    {
+        if (null != maxWidth)
+        {
+            put(Attribute.MAX_WIDTH.getProperty(), maxWidth);
+        }
+        else
+        {
+            remove(Attribute.MAX_WIDTH.getProperty());
+        }
+    }
+
+    public final void setMinHeight(final Double minHeight)
+    {
+        if (null != minHeight)
+        {
+            put(Attribute.MIN_HEIGHT.getProperty(), minHeight);
+        }
+        else
+        {
+            remove(Attribute.MIN_HEIGHT.getProperty());
+        }
+    }
+
+    public final void setMaxHeight(final Double maxHeight)
+    {
+        if (null != maxHeight)
+        {
+            put(Attribute.MAX_HEIGHT.getProperty(), maxHeight);
+        }
+        else
+        {
+            remove(Attribute.MAX_HEIGHT.getProperty());
+        }
+    }
+
     public final void setPoints(final Point2DArray points)
     {
         if (null != points)
@@ -1063,6 +1111,26 @@ public class Attributes
     public final double getHeight()
     {
         return getDouble(Attribute.HEIGHT.getProperty());
+    }
+
+    public final Double getMinWidth() {
+        double minWidth = getDouble(Attribute.MIN_WIDTH.getProperty());
+        return minWidth == 0 ? null : minWidth;
+    }
+
+    public final Double getMaxWidth() {
+        double maxWidth = getDouble(Attribute.MAX_WIDTH.getProperty());
+        return maxWidth == 0 ? null : maxWidth;
+    }
+
+    public final Double getMinHeight() {
+        double minHeight = getDouble(Attribute.MIN_HEIGHT.getProperty());
+        return minHeight == 0 ? null : minHeight;
+    }
+
+    public final Double getMaxHeight() {
+        double maxHeight = getDouble(Attribute.MAX_HEIGHT.getProperty());
+        return maxHeight == 0 ? null : maxHeight;
     }
 
     public final int getStarPoints()

--- a/src/test/java/com/ait/lienzo/client/core/shape/MultiPathTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/MultiPathTest.java
@@ -1,0 +1,73 @@
+/*
+ *
+ *    Copyright (c) 2018 Ahome' Innovation Technologies. All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+package com.ait.lienzo.client.core.shape;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class MultiPathTest {
+
+    private MultiPath tested;
+
+    @Before
+    public void setup() {
+        tested = new MultiPath().rect(0, 0, 100, 100);
+    }
+
+    @Test
+    public void testSetMinWidth() {
+        tested.setMinWidth(null);
+        assertNull(tested.getMinWidth());
+
+        tested.setMinWidth(20d);
+        assertEquals(tested.getMinWidth(), 20d, 0.0001);
+    }
+
+    @Test
+    public void testSetMaxWidth() {
+        tested.setMaxWidth(null);
+        assertNull(tested.getMaxWidth());
+
+        tested.setMaxWidth(150d);
+        assertEquals(tested.getMaxWidth(), 150d, 0.0001);
+    }
+
+    @Test
+    public void testSetMinHeight() {
+        tested.setMinHeight(null);
+        assertNull(tested.getMinHeight());
+
+        tested.setMinHeight(20d);
+        assertEquals(tested.getMinHeight(), 20d, 0.0001);
+    }
+
+    @Test
+    public void testSetMaxHeight() {
+        tested.setMaxHeight(null);
+        assertNull(tested.getMaxHeight());
+
+        tested.setMaxHeight(150d);
+        assertEquals(tested.getMaxHeight(), 150d, 0.0001);
+    }
+}


### PR DESCRIPTION
Issue:
[RHPAM-845](https://issues.jboss.org/browse/RHPAM-845)
[JBPM-7129](https://issues.jboss.org/browse/JBPM-7129) 

Cherry-pick: 
commit 3d8a6f0521ceb78121219dee71aa6e206a003f44

**This PR depends on kiegroup/lienzo-core.**

**7.7.x Branch PR's:**
kiegroup/kie-wb-common:
https://github.com/kiegroup/kie-wb-common/pull/1677
kiegroup/lienzo-core:
https://github.com/kiegroup/lienzo-core/pull/20
kiegroup/lienzo-tests
[_this one_](https://github.com/kiegroup/lienzo-tests/pull/16)

**Master PR's:**
_kiegroup/kie-wb-common_
https://github.com/kiegroup/kie-wb-common/pull/1641
_kiegroup/lienzo-core:_
https://github.com/kiegroup/lienzo-core/pull/18
_kiegroup/lienzo-tests_
https://github.com/kiegroup/lienzo-tests/pull/14

@romartin
