### PR TITLE
Enable disabled tests for jenkins

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/suite/WiresTestSuite.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/suite/WiresTestSuite.java
@@ -16,8 +16,6 @@
 
 package com.ait.lienzo.client.core.shape.wires.suite;
 
-import com.ait.lienzo.client.core.shape.TextBoundsWrapTest;
-import com.ait.lienzo.client.core.shape.TextLineBreakWrapTest;
 import com.ait.lienzo.client.core.shape.wires.WiresContainerTest;
 import com.ait.lienzo.client.core.shape.wires.WiresManagerTest;
 import com.ait.lienzo.client.core.shape.wires.WiresShapeControlHandleListTest;
@@ -25,6 +23,7 @@ import com.ait.lienzo.client.core.shape.wires.WiresShapeTest;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeHandlerImplTest;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresCompositeShapeHandlerTest;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresConnectorControlImplTest;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresDockingControlImplTest;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerControlImplTest;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeLocationControlImplTest;
 import org.junit.AfterClass;
@@ -38,17 +37,18 @@ import org.junit.runners.Suite;
  * @since 1.0.0-RC2
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({WiresContainerTest.class,
-        WiresShapeTest.class,
-        WiresShapeControlHandleListTest.class,
-        WiresShapeLocationControlImplTest.class,
-        WiresParentPickerControlImplTest.class,
-        WiresConnectorControlImplTest.class,
-        WiresShapeHandlerImplTest.class,
+@Suite.SuiteClasses({
         WiresCompositeShapeHandlerTest.class,
+        WiresConnectorControlImplTest.class,
+        WiresContainerTest.class,
+        WiresDockingControlImplTest.class,
         WiresManagerTest.class,
-        TextBoundsWrapTest.class,
-        TextLineBreakWrapTest.class})
+        WiresParentPickerControlImplTest.class,
+        WiresShapeControlHandleListTest.class,
+        WiresShapeHandlerImplTest.class,
+        WiresShapeLocationControlImplTest.class,
+        WiresShapeTest.class
+})
 public class WiresTestSuite {
 
     @BeforeClass

--- a/src/test/java/com/ait/lienzo/test/suite/TestSuite.java
+++ b/src/test/java/com/ait/lienzo/test/suite/TestSuite.java
@@ -18,29 +18,51 @@
 
 package com.ait.lienzo.test.suite;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
+import com.ait.lienzo.client.core.shape.AbstractOffsetMultiPointShapeTest;
+import com.ait.lienzo.client.core.shape.PolyLineTest;
+import com.ait.lienzo.client.core.shape.TextBoundsWrapTest;
+import com.ait.lienzo.client.core.shape.TextLineBreakWrapTest;
+import com.ait.lienzo.client.core.shape.wires.MagnetManagerTest;
+import com.ait.lienzo.client.core.shape.wires.SelectionManagerTest;
+import com.ait.lienzo.client.core.types.BoundingBoxTest;
+import com.ait.lienzo.client.widget.LienzoHandlerManagerTest;
+import com.ait.lienzo.client.widget.LienzoPanelTest;
 import com.ait.lienzo.test.BasicLienzoMockTest;
 import com.ait.lienzo.test.BasicLienzoStateTest;
 import com.ait.lienzo.test.JSOMockTest;
 import com.ait.lienzo.test.PointsMockTest;
 import com.ait.lienzo.test.PointsTest;
 import com.ait.lienzo.test.stub.custom.StubPointsTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * Lienzo testing suite.
- *
  * @author Roger Martinez
  * @since 1.0
- *
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ BasicLienzoMockTest.class, BasicLienzoStateTest.class, JSOMockTest.class, PointsTest.class, PointsMockTest.class, StubPointsTest.class })
-public class TestSuite
-{
+@Suite.SuiteClasses({
+        AbstractOffsetMultiPointShapeTest.class,
+        BasicLienzoMockTest.class,
+        BasicLienzoStateTest.class,
+        BoundingBoxTest.class,
+        JSOMockTest.class,
+        LienzoHandlerManagerTest.class,
+        LienzoPanelTest.class,
+        MagnetManagerTest.class,
+        PointsMockTest.class,
+        PointsTest.class,
+        PolyLineTest.class,
+        SelectionManagerTest.class,
+        StubPointsTest.class,
+        TextBoundsWrapTest.class,
+        TextLineBreakWrapTest.class
+})
+public class TestSuite {
+
     @BeforeClass
     public static void setUpClass()
     {


### PR DESCRIPTION
Hi @romartin,

I noticed that some tests where disabled for jenkins. There are a fix for that. But in my opinion it is worth to think about change trigger in `pom.xml` from `<include>**/*TestSuite.java</include>` to `<include>**/*Test.java</include>` to avoid this situation in the future.