### PR TITLE
JBPM-7715 (Stunner) - Align and distributions are shown incorrectly for the first alignment

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/AlignAndDistributeControlImplTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/AlignAndDistributeControlImplTest.java
@@ -104,4 +104,13 @@ public class AlignAndDistributeControlImplTest extends AbstractWiresControlTest 
         spied.refresh();
         verify(spied, never()).updateIndex();
     }
+
+    @Test
+    public void addHandlerTest() {
+        verify(group).addAttributesChangedHandler(Attribute.X, tested.ShapeAttributesChangedHandler);
+        verify(group).addAttributesChangedHandler(Attribute.Y, tested.ShapeAttributesChangedHandler);
+        verify(group).addAttributesChangedHandler(Attribute.ROTATION, tested.ShapeAttributesChangedHandler);
+        verify(group).addAttributesChangedHandler(Attribute.SCALE, tested.ShapeAttributesChangedHandler);
+        verify(group).addAttributesChangedHandler(Attribute.SHEAR, tested.ShapeAttributesChangedHandler);
+    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBPM-7715

Diagram's child element attribute changes weren't been listened to.
This fixes it.