### PR TITLE
JBPM-7718 increase the wrapping size on connector label

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorHandlerImplTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorHandlerImplTest.java
@@ -15,8 +15,9 @@
  */
 package com.ait.lienzo.client.core.shape.wires.handlers.impl;
 
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 import com.ait.lienzo.client.core.event.NodeDragEndEvent;
 import com.ait.lienzo.client.core.event.NodeDragMoveEvent;
@@ -140,7 +141,7 @@ public class WiresConnectorHandlerImplTest {
                                                clickTimer);
 
         //clear token that controls concurrency
-        ConcurrentHashMap<String, Boolean> transientControlHandleTokenMap = (ConcurrentHashMap<String, Boolean>) Whitebox.getInternalState(tested, "transientControlHandleTokenMap");
+        Map<String, Boolean> transientControlHandleTokenMap = (HashMap<String, Boolean>) Whitebox.getInternalState(tested, "transientControlHandleTokenMap");
         transientControlHandleTokenMap.clear();
     }
 


### PR DESCRIPTION
Fix `WiresConnectorHandlerImplTest` removing the `ConcurrentHashMap` dependency, that is not on the GWT 2.7.

