### PR TITLE
Fix possible OutOfRange

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/OrthogonalPolyLineTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/OrthogonalPolyLineTest.java
@@ -1,0 +1,108 @@
+package com.ait.lienzo.client.core.shape;
+
+import com.ait.lienzo.client.core.types.BoundingBox;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
+import com.ait.lienzo.shared.core.types.Direction;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static com.ait.lienzo.client.core.shape.OrthogonalPolyLine.correctEndWithOffset;
+import static com.ait.lienzo.shared.core.types.Direction.EAST;
+import static com.ait.lienzo.shared.core.types.Direction.NONE;
+import static com.ait.lienzo.shared.core.types.Direction.NORTH;
+import static com.ait.lienzo.shared.core.types.Direction.NORTH_EAST;
+import static com.ait.lienzo.shared.core.types.Direction.SOUTH;
+import static com.ait.lienzo.shared.core.types.Direction.WEST;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class OrthogonalPolyLineTest
+{
+
+    @Mock
+    Point2DArray array;
+
+    @Mock
+    Attributes attributes;
+
+    @Test
+    public void testGetBoundingBoxForEmptyPath()
+    {
+        when(array.size()).thenReturn(0);
+
+        OrthogonalPolyLine polyLine = new OrthogonalPolyLine(array);
+        BoundingBox box = polyLine.getBoundingBox();
+
+        assertEquals(0, box.getMinX(), 0.000001);
+        assertEquals(0, box.getMinY(), 0.000001);
+        assertEquals(0, box.getMaxX(), 0.000001);
+        assertEquals(0, box.getMaxY(), 0.000001);
+    }
+
+    @Test
+    public void testParse()
+    {
+        Point2DArray points = new Point2DArray();
+        when(attributes.getControlPoints()).thenReturn(points);
+        when(attributes.getHeadDirection()).thenReturn(NONE);
+        when(attributes.getTailDirection()).thenReturn(NONE);
+        OrthogonalPolyLine polyLine = spy(new OrthogonalPolyLine(points));
+        assertFalse(polyLine.parse(attributes));
+
+        points.push(0, 0);
+        points.push(5, 5);
+        assertTrue(polyLine.parse(attributes));
+    }
+
+    @Test
+    public void testCorrectEndWithNorthOffset()
+    {
+        testCorrectEndWithOffset(NORTH, 3, 0);
+    }
+
+    @Test
+    public void testCorrectEndWithEastOffset()
+    {
+        testCorrectEndWithOffset(EAST, 6, 3);
+    }
+
+    @Test
+    public void testCorrectEndWithSouthOffset()
+    {
+        testCorrectEndWithOffset(SOUTH, 3, 6);
+    }
+
+    @Test
+    public void testCorrectEndWithWestOffset()
+    {
+        testCorrectEndWithOffset(WEST, 0, 3);
+    }
+
+    @Test
+    public void testCorrectEndWithNONEOffset()
+    {
+        testCorrectEndWithOffset(NONE, 3, 3);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCorrectEndWithOffsetWithWrongDirection()
+    {
+        testCorrectEndWithOffset(NORTH_EAST, 1000, 1000);
+    }
+
+    private void testCorrectEndWithOffset(Direction direction, double expectedX, double expectedY)
+    {
+        Point2D point = new Point2D(3, 3);
+        double offset = 3;
+        point = correctEndWithOffset(offset, direction, point);
+        assertEquals(expectedX, point.getX(), 0.0000001);
+        assertEquals(expectedY, point.getY(), 0.0000001);
+    }
+}

--- a/src/test/java/com/ait/lienzo/client/core/shape/PolyLineTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/PolyLineTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -39,6 +40,13 @@ public class PolyLineTest {
     public void setup() {
         polyLine = new PolyLine();
         attributes = makeAttributes();
+    }
+
+    @Test
+    public void testParseWhenPointsSizeIsEmpty() {
+        doReturn(new Point2DArray()).when(attributes).getPoints();
+
+        assertFalse(polyLine.parse(attributes));
     }
 
     @Test

--- a/src/test/java/com/ait/lienzo/client/core/suite/LienzoCoreTestSuite.java
+++ b/src/test/java/com/ait/lienzo/client/core/suite/LienzoCoreTestSuite.java
@@ -17,11 +17,13 @@
 package com.ait.lienzo.client.core.suite;
 
 import com.ait.lienzo.client.core.image.ImageElementProxyTest;
+import com.ait.lienzo.client.core.image.ImageProxyTest;
 import com.ait.lienzo.client.core.image.ImageStripsTest;
 import com.ait.lienzo.client.core.image.ImageTest;
 import com.ait.lienzo.client.core.shape.BezierCurveTest;
 import com.ait.lienzo.client.core.shape.BoundingBoxComputationsTest;
 import com.ait.lienzo.client.core.shape.MultiPathTest;
+import com.ait.lienzo.client.core.shape.OrthogonalPolyLineTest;
 import com.ait.lienzo.client.core.shape.PolyLineTest;
 import com.ait.lienzo.client.core.shape.TextBoundsWrapTest;
 import com.ait.lienzo.client.core.shape.TextLineBreakWrapTest;
@@ -40,11 +42,13 @@ import org.junit.runners.Suite;
         BoundingBoxTest.class,
         BoundingBoxComputationsTest.class,
         ImageElementProxyTest.class,
+        ImageProxyTest.class,
         ImageStripsTest.class,
         ImageTest.class,
         LienzoHandlerManagerTest.class,
         LienzoPanelTest.class,
         MultiPathTest.class,
+        OrthogonalPolyLineTest.class,
         PolyLineTest.class,
         BezierCurveTest.class,
         TextBoundsWrapTest.class,

--- a/src/test/java/com/ait/lienzo/client/core/suite/WiresTestSuite.java
+++ b/src/test/java/com/ait/lienzo/client/core/suite/WiresTestSuite.java
@@ -40,6 +40,8 @@ import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerCon
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeControlImplTest;
 import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeLocationControlImplTest;
 import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPickerTest;
+import com.ait.lienzo.client.core.shape.wires.util.WiresConnectorLabelFactoryTest;
+import com.ait.lienzo.client.core.shape.wires.util.WiresConnectorLabelTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -58,6 +60,8 @@ import org.junit.runners.Suite;
         WiresCompositeShapeHandlerTest.class,
         WiresConnectorControlImplTest.class,
         WiresConnectorHandlerImplTest.class,
+        WiresConnectorLabelFactoryTest.class,
+        WiresConnectorLabelTest.class,
         WiresConnectorTest.class,
         WiresContainerTest.class,
         WiresDockingControlImplTest.class,

--- a/src/test/java/com/ait/lienzo/test/suite/TestSuite.java
+++ b/src/test/java/com/ait/lienzo/test/suite/TestSuite.java
@@ -21,6 +21,7 @@ package com.ait.lienzo.test.suite;
 import com.ait.lienzo.test.BasicLienzoMockTest;
 import com.ait.lienzo.test.BasicLienzoStateTest;
 import com.ait.lienzo.test.JSOMockTest;
+import com.ait.lienzo.test.LienzoCoreAttributesTest;
 import com.ait.lienzo.test.PointsMockTest;
 import com.ait.lienzo.test.PointsTest;
 import com.ait.lienzo.test.stub.custom.StubPointsTest;
@@ -39,6 +40,7 @@ import org.junit.runners.Suite;
         BasicLienzoMockTest.class,
         BasicLienzoStateTest.class,
         JSOMockTest.class,
+        LienzoCoreAttributesTest.class,
         PointsTest.class,
         PointsMockTest.class,
         StubPointsTest.class


### PR DESCRIPTION
Hi @wmedvede, @romartin 

this is tests for fixed method which always returned true, as described here: https://github.com/wmedvede/lienzo-core/pull/1

I found out that `PolyLine#parse` method never returns `false` value.
 
Array newer will be null, but can be empty. Also some usages (`WiresConnector#updateHeadTailForRefreshedConnector`) of this method relay that if this method returns `true` it means there are some values and starts to use it's values:

**`WiresConnector#updateHeadTailForRefreshedConnector`**
```java
final boolean prepared = line.isPathPartListPrepared(c.getLine().getAttributes());

if (!prepared)
{
        return true;
}

Point2DArray points     = line.getPoint2DArray();
Point2D      p0         = points.get(0);
```

**`AbstractOffsetMultiPointShape#isPathPartListPrepared`**
```java
public boolean isPathPartListPrepared(final Attributes attr)
{
    if (getPathPartList().size() < 1)
    {
        return parse(attr);
    }

    return true;
}
```