### PR TITLE
JBPM-7854 - Error while moving the mouse over the explorer panel

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorHandlerImplTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresConnectorHandlerImplTest.java
@@ -207,6 +207,14 @@ public class WiresConnectorHandlerImplTest {
     }
 
     @Test
+    public void testSelectionManagerIsNull()
+    {
+        // no assert intentionally, before the fix this tests failed with NullPointer Exception
+        when(wiresManager.getSelectionManager()).thenReturn(null);
+        tested.onNodeMouseMove(moveEvent);
+    }
+
+    @Test
     public void testMoveAndCreateControlPoint() {
         when(moveEvent.getX()).thenReturn(20);
         when(moveEvent.getY()).thenReturn(20);


### PR DESCRIPTION
Hi @romartin there is a test for my workaround.

Right now tests are failing with unrelated issue (see below), but @tiagodolphine already working on it.

```
[ERROR] Failures: 
[ERROR]   WiresConnectorLabelFactoryTest.testSegmentLabelExecutor:70 expected: com.ait.lienzo.client.core.types.Point2D<{}> but was: com.ait.lienzo.client.core.types.Point2D<{}>
```