### PR TITLE
Fix WiresConnectorLabelFactoryTest

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/util/WiresConnectorLabelFactoryTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/util/WiresConnectorLabelFactoryTest.java
@@ -67,7 +67,7 @@ public class WiresConnectorLabelFactoryTest {
         assertNotNull(text.getWrapper());
         TextBoundsWrap wrapper = (TextBoundsWrap) text.getWrapper();
         assertEquals(new BoundingBox(0d, 0d, 22.808989455914087d, 11d), wrapper.getWrapBoundaries());
-        assertEquals(new Point2D(23.987684456439d, 15.865763679785857d), text.getLocation());
+        assertEquals(new Point2D(18.987684456439d, 15.865763679785857d), text.getLocation());
     }
 
     @Test


### PR DESCRIPTION
Fixing a broken test on `WiresConnectorLabelFactoryTest` caused by last merge.

@romartin 
@hasys 