### PR TITLE
Align surefire version with kiegroup projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.1</version>
         <configuration>
           <includes>
             <include>**/*TestSuite.java</include>


### PR DESCRIPTION
Bump surefire to the version used in other kiegroup repos (required to enable JDK 11 testing)
@romartin please check and merge.