### PR TITLE
DROOLS-3504: Include DragBundsJSO to default stub

### DIFF
--- a/src/main/java/com/ait/lienzo/test/settings/DefaultSettingsHolder.java
+++ b/src/main/java/com/ait/lienzo/test/settings/DefaultSettingsHolder.java
@@ -49,6 +49,7 @@ import com.ait.lienzo.test.translator.StripFinalModifiersTranslatorInterceptor;
 
         stubs = {
                 com.ait.lienzo.test.stub.overlays.BoundingBoxJSO.class,
+                com.ait.lienzo.test.stub.overlays.DragBoundsJSO.class,
                 com.ait.lienzo.test.stub.overlays.TransformJSO.class,
                 com.ait.lienzo.test.stub.overlays.ShadowJSO.class,
                 com.ait.lienzo.test.stub.overlays.NObjectJSO.class,


### PR DESCRIPTION
@manstis  @romartin could you please have a look?

One question, I spotted the [DragBoundsJSO class](https://github.com/kiegroup/lienzo-tests/blob/master/src/main/java/com/ait/lienzo/test/stub/overlays/DragBoundsJSO.java) has not a license, should I add some?