### PR TITLE
JBPM-8029: JDK11 LienzoMockitoTestRunner compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.com.google.gwt>2.7.0</version.com.google.gwt>
     <version.junit>4.11</version.junit>
-    <version.org.mockito>1.9.5</version.org.mockito>
-    <version.org.javassist>3.17.1-GA</version.org.javassist>
-    <version.com.google.gwt.gwtmockito>1.1.6</version.com.google.gwt.gwtmockito>
+    <version.org.mockito>1.10.19</version.org.mockito>
+    <version.org.javassist>3.22.0-GA</version.org.javassist>
+    <version.com.google.gwt.gwtmockito>1.1.8</version.com.google.gwt.gwtmockito>
 
   </properties>
 

--- a/src/test/java/com/ait/lienzo/client/core/util/GeometryTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/util/GeometryTest.java
@@ -174,7 +174,8 @@ public class GeometryTest {
         final double[] ly = new double[]{0, 100};
         Point2DArray result = Geometry.intersectLineCurve(xval, yval, lx, ly);
         assertEquals(2, result.size());
-        assertEquals(new Point2D(50d, 20d), result.get(0));
+        assertEquals(50d, result.get(0).getX(), 0.00001);
+        assertEquals(20d, result.get(0).getY(), 0.00001);
         assertEquals(new Point2D(144.49725985049355d, 57.79890394019752d), result.get(1));
     }
 


### PR DESCRIPTION
Hi @romartin, @jomarko,

I aligned dependencies for Java 11. Works good now for both Java 8 and Java 11.