### PR TITLE
Fixing the returned instance for Point2DJSO#add method call.

### DIFF
--- a/src/main/java/com/ait/lienzo/test/stub/overlays/Point2DJSO.java
+++ b/src/main/java/com/ait/lienzo/test/stub/overlays/Point2DJSO.java
@@ -117,7 +117,7 @@ public class Point2DJSO extends JavaScriptObject
     {
         this.x += jso.x;
         this.y += jso.y;
-        return new Point2DJSO(this.x, this.y);
+        return this;
     }
 
     public void offset(final double x, final double y)


### PR DESCRIPTION
Hey @manstis 

Here is the fix for the failed test case in uberfire: `
org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.BaseCellSelectionManagerTest.startEditingCellPointCoordinateWithinGridBounds`

Sorry for the inconveniences! 
Thx!