### PR TITLE
BXMSPROD-494 allow GA build on windows machine

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,11 +16,18 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
-      - name: Install takari
+      - name: Install takari (non-windows)
+        if: ${{ matrix.os != 'windows-latest' }}
         run: |
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar
           wget -P $M2_HOME/lib/ext https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar
+      - name: Install takari (windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.3/takari-local-repository-0.11.3.jar", "$Env:M2_HOME\lib\ext\takari-local-repository-0.11.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar", "$Env:M2_HOME\lib\ext\takari-filemanager-0.8.3.jar")
+          (New-Object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/io/takari/maven/takari-smart-builder/0.6.1/takari-smart-builder-0.6.1.jar", "$Env:M2_HOME\lib\ext\takari-smart-builder-0.6.1.jar")
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
         uses: kiegroup/github-action-build-chain@v1.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,9 +6,10 @@ jobs:
   build-chain:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         java-version: [8, 11]
       fail-fast: true
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     name: Maven Build
     steps:
       - name: Set up JDK


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-494

related to

https://github.com/kiegroup/lienzo-core/pull/133
https://github.com/kiegroup/lienzo-tests/pull/108
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1471
https://github.com/kiegroup/kie-soup/pull/158
https://github.com/kiegroup/appformer/pull/1054
https://github.com/kiegroup/droolsjbpm-knowledge/pull/465
https://github.com/kiegroup/drools/pull/3116
https://github.com/kiegroup/optaplanner/pull/940
https://github.com/kiegroup/jbpm/pull/1758
https://github.com/kiegroup/kie-jpmml-integration/pull/43
https://github.com/kiegroup/droolsjbpm-integration/pull/2243
https://github.com/kiegroup/openshift-drools-hacep/pull/100
https://github.com/kiegroup/droolsjbpm-tools/pull/118
https://github.com/kiegroup/kie-uberfire-extensions/pull/106
https://github.com/kiegroup/kie-wb-playground/pull/97
https://github.com/kiegroup/kie-wb-common/pull/3423
https://github.com/kiegroup/drools-wb/pull/1423
https://github.com/kiegroup/optaplanner-wb/pull/381
https://github.com/kiegroup/jbpm-designer/pull/891
https://github.com/kiegroup/jbpm-wb/pull/1461
https://github.com/kiegroup/jbpm-work-items/pull/153
https://github.com/kiegroup/kie-docs/pull/2849
https://github.com/kiegroup/optaweb-employee-rostering/pull/498
https://github.com/kiegroup/optaweb-vehicle-routing/pull/367
https://github.com/kiegroup/kie-wb-distributions/pull/1062