### PR TITLE
[RHPAM-4505] Revert "RHPAM-4387 xercesImpl to 2.12.2 (#136)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <version.org.mockito>1.10.19</version.org.mockito>
     <version.org.javassist>3.22.0-GA</version.org.javassist>
     <version.com.google.gwt.gwtmockito>1.1.8</version.com.google.gwt.gwtmockito>
-    <version.xerces>2.12.2</version.xerces>
 
   </properties>
 
@@ -67,13 +66,6 @@
       <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
       <version>${version.org.kie.lienzo}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-      <version>${version.xerces}</version>
       <scope>provided</scope>
     </dependency>
     


### PR DESCRIPTION
This reverts commit 348ebe5e5e46e66171c55a3369832b6e8c573c22.

**JIRA**: 
https://issues.redhat.com/browse/RHPAM-4505

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2067
* https://github.com/kiegroup/kie-wb-common/pull/3775

Changes by RHPAM-4387 in `drools-wb`, `jbpm-wb`, `kie-wb-distributions` were already reverted in main (7.x)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
